### PR TITLE
Retrieve data on demand

### DIFF
--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -214,7 +214,7 @@ int LuaPerlinNoiseMap::l_get2dMap_flat_helper(lua_State *L)
 
 	LuaPerlinNoiseMap *o = checkobject(L, lua_upvalueindex(1));
 	Noise *n = o->noise;
-	lua_Integer i = lua_tointeger(L, 2)-1;
+	size_t i = lua_tointeger(L, 2)-1;
 	lua_Number ni = n->result[i];
 
 	lua_pushnumber(L, ni);
@@ -231,7 +231,7 @@ int LuaPerlinNoiseMap::l_get2dMap_flat(lua_State *L)
 	Noise *n = o->noise;
 	n->perlinMap2D(p.X, p.Y);
 
-	lua_newtable(L);
+	lua_newuserdata(L, 0);
 	lua_newtable(L);
 
 	lua_pushliteral(L, "__index");
@@ -309,7 +309,7 @@ int LuaPerlinNoiseMap::l_get3dMap_flat_helper(lua_State *L)
 
 	LuaPerlinNoiseMap *o = checkobject(L, lua_upvalueindex(1));
 	Noise *n = o->noise;
-	lua_Integer i = lua_tointeger(L, 2)-1;
+	size_t i = lua_tointeger(L, 2)-1;
 	lua_Number ni = n->result[i];
 
 	lua_pushnumber(L, ni);
@@ -329,7 +329,7 @@ int LuaPerlinNoiseMap::l_get3dMap_flat(lua_State *L)
 	Noise *n = o->noise;
 	n->perlinMap3D(p.X, p.Y, p.Z);
 
-	lua_newtable(L);
+	lua_newuserdata(L, 0);
 	lua_newtable(L);
 
 	lua_pushliteral(L, "__index");

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -214,7 +214,7 @@ int LuaPerlinNoiseMap::l_get2dMap_flat_helper(lua_State *L)
 
 	LuaPerlinNoiseMap *o = checkobject(L, lua_upvalueindex(1));
 	Noise *n = o->noise;
-	lua_Integer i = lua_tointeger(L, 2);
+	lua_Integer i = lua_tointeger(L, 2)-1;
 	lua_Number ni = n->result[i];
 
 	lua_pushnumber(L, ni);
@@ -309,7 +309,7 @@ int LuaPerlinNoiseMap::l_get3dMap_flat_helper(lua_State *L)
 
 	LuaPerlinNoiseMap *o = checkobject(L, lua_upvalueindex(1));
 	Noise *n = o->noise;
-	lua_Integer i = lua_tointeger(L, 2);
+	lua_Integer i = lua_tointeger(L, 2)-1;
 	lua_Number ni = n->result[i];
 
 	lua_pushnumber(L, ni);
@@ -321,10 +321,13 @@ int LuaPerlinNoiseMap::l_get3dMap_flat(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 
 	LuaPerlinNoiseMap *o = checkobject(L, 1);
-	v2f p                = check_v2f(L, 2);
+	v3f p                = check_v3f(L, 2);
+
+	if (!o->m_is3d)
+		return 0;
 
 	Noise *n = o->noise;
-	n->perlinMap2D(p.X, p.Y);
+	n->perlinMap3D(p.X, p.Y, p.Z);
 
 	lua_newtable(L);
 	lua_newtable(L);

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -183,7 +183,7 @@ int LuaPerlinNoiseMap::l_get2dMap(lua_State *L)
 }
 
 
-int LuaPerlinNoiseMap::l_get2dMap_flat(lua_State *L)
+int LuaPerlinNoiseMap::l_get2dMap_flat2(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
@@ -208,6 +208,41 @@ int LuaPerlinNoiseMap::l_get2dMap_flat(lua_State *L)
 	return 1;
 }
 
+int LuaPerlinNoiseMap::l_get2dMap_flat_helper(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaPerlinNoiseMap *o = checkobject(L, lua_upvalueindex(1));
+	Noise *n = o->noise;
+	lua_Integer i = lua_tointeger(L, 2);
+	lua_Number ni = n->result[i];
+
+	lua_pushnumber(L, ni);
+	return 1;
+}
+
+int LuaPerlinNoiseMap::l_get2dMap_flat(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaPerlinNoiseMap *o = checkobject(L, 1);
+	v2f p                = check_v2f(L, 2);
+
+	Noise *n = o->noise;
+	n->perlinMap2D(p.X, p.Y);
+
+	lua_newtable(L);
+	lua_newtable(L);
+
+	lua_pushliteral(L, "__index");
+	lua_pushvalue(L, 1);
+	lua_pushcclosure(L, l_get2dMap_flat_helper, 1);
+	lua_settable(L, -3);
+
+	lua_setmetatable(L, -2);
+
+	return 1;
+}
 
 int LuaPerlinNoiseMap::l_get3dMap(lua_State *L)
 {
@@ -240,7 +275,7 @@ int LuaPerlinNoiseMap::l_get3dMap(lua_State *L)
 }
 
 
-int LuaPerlinNoiseMap::l_get3dMap_flat(lua_State *L)
+int LuaPerlinNoiseMap::l_get3dMap_flat2(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
@@ -268,6 +303,41 @@ int LuaPerlinNoiseMap::l_get3dMap_flat(lua_State *L)
 	return 1;
 }
 
+int LuaPerlinNoiseMap::l_get3dMap_flat_helper(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaPerlinNoiseMap *o = checkobject(L, lua_upvalueindex(1));
+	Noise *n = o->noise;
+	lua_Integer i = lua_tointeger(L, 2);
+	lua_Number ni = n->result[i];
+
+	lua_pushnumber(L, ni);
+	return 1;
+}
+
+int LuaPerlinNoiseMap::l_get3dMap_flat(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaPerlinNoiseMap *o = checkobject(L, 1);
+	v2f p                = check_v2f(L, 2);
+
+	Noise *n = o->noise;
+	n->perlinMap2D(p.X, p.Y);
+
+	lua_newtable(L);
+	lua_newtable(L);
+
+	lua_pushliteral(L, "__index");
+	lua_pushvalue(L, 1);
+	lua_pushcclosure(L, l_get3dMap_flat_helper, 1);
+	lua_settable(L, -3);
+
+	lua_setmetatable(L, -2);
+
+	return 1;
+}
 
 int LuaPerlinNoiseMap::l_calc2dMap(lua_State *L)
 {
@@ -391,9 +461,11 @@ const char LuaPerlinNoiseMap::className[] = "PerlinNoiseMap";
 const luaL_Reg LuaPerlinNoiseMap::methods[] = {
 	luamethod(LuaPerlinNoiseMap, get2dMap),
 	luamethod(LuaPerlinNoiseMap, get2dMap_flat),
+	luamethod(LuaPerlinNoiseMap, get2dMap_flat2),
 	luamethod(LuaPerlinNoiseMap, calc2dMap),
 	luamethod(LuaPerlinNoiseMap, get3dMap),
 	luamethod(LuaPerlinNoiseMap, get3dMap_flat),
+	luamethod(LuaPerlinNoiseMap, get3dMap_flat2),
 	luamethod(LuaPerlinNoiseMap, calc3dMap),
 	luamethod(LuaPerlinNoiseMap, getMapSlice),
 	{0,0}

--- a/src/script/lua_api/l_noise.h
+++ b/src/script/lua_api/l_noise.h
@@ -72,8 +72,12 @@ class LuaPerlinNoiseMap : public ModApiBase
 
 	static int l_get2dMap(lua_State *L);
 	static int l_get2dMap_flat(lua_State *L);
+	static int l_get2dMap_flat_helper(lua_State *L);
+	static int l_get2dMap_flat2(lua_State *L);
 	static int l_get3dMap(lua_State *L);
 	static int l_get3dMap_flat(lua_State *L);
+	static int l_get3dMap_flat_helper(lua_State *L);
+	static int l_get3dMap_flat2(lua_State *L);
 
 	static int l_calc2dMap(lua_State *L);
 	static int l_calc3dMap(lua_State *L);

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -58,7 +58,7 @@ int LuaVoxelManip::l_read_from_map(lua_State *L)
 	return 2;
 }
 
-int LuaVoxelManip::l_get_data(lua_State *L)
+int LuaVoxelManip::l_get_data2(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
@@ -104,6 +104,80 @@ int LuaVoxelManip::l_set_data(lua_State *L)
 	}
 
 	return 0;
+}
+
+int LuaVoxelManip::l_get_content_at(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaVoxelManip *o = checkobject(L, 1);
+	MMVManip *vm = o->vm;
+	lua_Integer i = lua_tointeger(L, 2);
+	lua_Integer cid = vm->m_data[i].getContent();
+
+	lua_pushinteger(L, cid);
+	return 1;
+}
+
+int LuaVoxelManip::l_set_content_at(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaVoxelManip *o = checkobject(L, 1);
+	MMVManip *vm = o->vm;
+	lua_Integer i = lua_tointeger(L, 2);
+	content_t c = lua_tointeger(L, 3);
+
+	vm->m_data[i].setContent(c);
+	return 0;
+}
+
+int LuaVoxelManip::l_get_content_at_helper(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaVoxelManip *o = checkobject(L, lua_upvalueindex(1));
+	MMVManip *vm = o->vm;
+	lua_Integer i = lua_tointeger(L, 2);
+	lua_Integer cid = vm->m_data[i].getContent();
+
+	lua_pushinteger(L, cid);
+	return 1;
+}
+
+int LuaVoxelManip::l_set_content_at_helper(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaVoxelManip *o = checkobject(L, lua_upvalueindex(1));
+	MMVManip *vm = o->vm;
+	lua_Integer i = lua_tointeger(L, 2);
+	content_t c = lua_tointeger(L, 3);
+
+	vm->m_data[i].setContent(c);
+	return 0;
+}
+
+int LuaVoxelManip::l_get_data(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	lua_newuserdata(L, 0);
+	lua_newtable(L);
+
+	lua_pushliteral(L, "__index");
+	lua_pushvalue(L, 1);
+	lua_pushcclosure(L, l_get_content_at_helper, 1);
+	lua_settable(L, -3);
+
+	lua_pushliteral(L, "__newindex");
+	lua_pushvalue(L, 1);
+	lua_pushcclosure(L, l_set_content_at_helper, 1);
+	lua_settable(L, -3);
+
+	lua_setmetatable(L, -2);
+
+	return 1;
 }
 
 int LuaVoxelManip::l_write_to_map(lua_State *L)
@@ -288,7 +362,7 @@ int LuaVoxelManip::l_set_light_data(lua_State *L)
 	return 0;
 }
 
-int LuaVoxelManip::l_get_param2_data(lua_State *L)
+int LuaVoxelManip::l_get_param2_data2(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
@@ -334,6 +408,80 @@ int LuaVoxelManip::l_set_param2_data(lua_State *L)
 	}
 
 	return 0;
+}
+
+int LuaVoxelManip::l_get_param2_at(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaVoxelManip *o = checkobject(L, 1);
+	MMVManip *vm = o->vm;
+	lua_Integer i = lua_tointeger(L, 2);
+	lua_Integer param2 = vm->m_data[i].param2;
+
+	lua_pushinteger(L, param2);
+	return 1;
+}
+
+int LuaVoxelManip::l_set_param2_at(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaVoxelManip *o = checkobject(L, 1);
+	MMVManip *vm = o->vm;
+	lua_Integer i = lua_tointeger(L, 2);
+	u8 param2 = lua_tointeger(L, 3);
+
+	vm->m_data[i].param2 = param2;
+	return 0;
+}
+
+int LuaVoxelManip::l_get_param2_at_helper(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaVoxelManip *o = checkobject(L, lua_upvalueindex(1));
+	MMVManip *vm = o->vm;
+	lua_Integer i = lua_tointeger(L, 2);
+	lua_Integer param2 = vm->m_data[i].param2;
+
+	lua_pushinteger(L, param2);
+	return 1;
+}
+
+int LuaVoxelManip::l_set_param2_at_helper(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	LuaVoxelManip *o = checkobject(L, lua_upvalueindex(1));
+	MMVManip *vm = o->vm;
+	lua_Integer i = lua_tointeger(L, 2);
+	u8 param2 = lua_tointeger(L, 3);
+
+	vm->m_data[i].param2 = param2;
+	return 0;
+}
+
+int LuaVoxelManip::l_get_param2_data(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	lua_newuserdata(L, 0);
+	lua_newtable(L);
+
+	lua_pushliteral(L, "__index");
+	lua_pushvalue(L, 1);
+	lua_pushcclosure(L, l_get_param2_at_helper, 1);
+	lua_settable(L, -3);
+
+	lua_pushliteral(L, "__newindex");
+	lua_pushvalue(L, 1);
+	lua_pushcclosure(L, l_set_param2_at_helper, 1);
+	lua_settable(L, -3);
+
+	lua_setmetatable(L, -2);
+
+	return 1;
 }
 
 int LuaVoxelManip::l_update_map(lua_State *L)
@@ -454,6 +602,9 @@ const luaL_Reg LuaVoxelManip::methods[] = {
 	luamethod(LuaVoxelManip, read_from_map),
 	luamethod(LuaVoxelManip, get_data),
 	luamethod(LuaVoxelManip, set_data),
+	luamethod(LuaVoxelManip, get_content_at),
+	luamethod(LuaVoxelManip, set_content_at),
+	luamethod(LuaVoxelManip, get_data2),
 	luamethod(LuaVoxelManip, get_node_at),
 	luamethod(LuaVoxelManip, set_node_at),
 	luamethod(LuaVoxelManip, write_to_map),
@@ -465,6 +616,9 @@ const luaL_Reg LuaVoxelManip::methods[] = {
 	luamethod(LuaVoxelManip, set_light_data),
 	luamethod(LuaVoxelManip, get_param2_data),
 	luamethod(LuaVoxelManip, set_param2_data),
+	luamethod(LuaVoxelManip, get_param2_at),
+	luamethod(LuaVoxelManip, set_param2_at),
+	luamethod(LuaVoxelManip, get_param2_data2),
 	luamethod(LuaVoxelManip, was_modified),
 	luamethod(LuaVoxelManip, get_emerged_area),
 	{0,0}

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -112,7 +112,7 @@ int LuaVoxelManip::l_get_content_at(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, 1);
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2);
+	lua_Integer i = lua_tointeger(L, 2)-1;
 	lua_Integer cid = vm->m_data[i].getContent();
 
 	lua_pushinteger(L, cid);
@@ -125,7 +125,7 @@ int LuaVoxelManip::l_set_content_at(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, 1);
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2);
+	lua_Integer i = lua_tointeger(L, 2)-1;
 	content_t c = lua_tointeger(L, 3);
 
 	vm->m_data[i].setContent(c);
@@ -138,7 +138,7 @@ int LuaVoxelManip::l_get_content_at_helper(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, lua_upvalueindex(1));
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2);
+	lua_Integer i = lua_tointeger(L, 2)-1;
 	lua_Integer cid = vm->m_data[i].getContent();
 
 	lua_pushinteger(L, cid);
@@ -151,7 +151,7 @@ int LuaVoxelManip::l_set_content_at_helper(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, lua_upvalueindex(1));
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2);
+	lua_Integer i = lua_tointeger(L, 2)-1;
 	content_t c = lua_tointeger(L, 3);
 
 	vm->m_data[i].setContent(c);
@@ -416,7 +416,7 @@ int LuaVoxelManip::l_get_param2_at(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, 1);
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2);
+	lua_Integer i = lua_tointeger(L, 2)-1;
 	lua_Integer param2 = vm->m_data[i].param2;
 
 	lua_pushinteger(L, param2);
@@ -429,7 +429,7 @@ int LuaVoxelManip::l_set_param2_at(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, 1);
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2);
+	lua_Integer i = lua_tointeger(L, 2)-1;
 	u8 param2 = lua_tointeger(L, 3);
 
 	vm->m_data[i].param2 = param2;
@@ -442,7 +442,7 @@ int LuaVoxelManip::l_get_param2_at_helper(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, lua_upvalueindex(1));
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2);
+	lua_Integer i = lua_tointeger(L, 2)-1;
 	lua_Integer param2 = vm->m_data[i].param2;
 
 	lua_pushinteger(L, param2);
@@ -455,7 +455,7 @@ int LuaVoxelManip::l_set_param2_at_helper(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, lua_upvalueindex(1));
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2);
+	lua_Integer i = lua_tointeger(L, 2)-1;
 	u8 param2 = lua_tointeger(L, 3);
 
 	vm->m_data[i].param2 = param2;

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -112,7 +112,7 @@ int LuaVoxelManip::l_get_content_at(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, 1);
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2)-1;
+	u32 i = lua_tointeger(L, 2)-1;
 	lua_Integer cid = vm->m_data[i].getContent();
 
 	lua_pushinteger(L, cid);
@@ -125,7 +125,7 @@ int LuaVoxelManip::l_set_content_at(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, 1);
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2)-1;
+	u32 i = lua_tointeger(L, 2)-1;
 	content_t c = lua_tointeger(L, 3);
 
 	vm->m_data[i].setContent(c);
@@ -138,7 +138,7 @@ int LuaVoxelManip::l_get_content_at_helper(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, lua_upvalueindex(1));
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2)-1;
+	u32 i = lua_tointeger(L, 2)-1;
 	lua_Integer cid = vm->m_data[i].getContent();
 
 	lua_pushinteger(L, cid);
@@ -151,7 +151,7 @@ int LuaVoxelManip::l_set_content_at_helper(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, lua_upvalueindex(1));
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2)-1;
+	u32 i = lua_tointeger(L, 2)-1;
 	content_t c = lua_tointeger(L, 3);
 
 	vm->m_data[i].setContent(c);
@@ -416,7 +416,7 @@ int LuaVoxelManip::l_get_param2_at(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, 1);
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2)-1;
+	u32 i = lua_tointeger(L, 2)-1;
 	lua_Integer param2 = vm->m_data[i].param2;
 
 	lua_pushinteger(L, param2);
@@ -429,7 +429,7 @@ int LuaVoxelManip::l_set_param2_at(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, 1);
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2)-1;
+	u32 i = lua_tointeger(L, 2)-1;
 	u8 param2 = lua_tointeger(L, 3);
 
 	vm->m_data[i].param2 = param2;
@@ -442,7 +442,7 @@ int LuaVoxelManip::l_get_param2_at_helper(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, lua_upvalueindex(1));
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2)-1;
+	u32 i = lua_tointeger(L, 2)-1;
 	lua_Integer param2 = vm->m_data[i].param2;
 
 	lua_pushinteger(L, param2);
@@ -455,7 +455,7 @@ int LuaVoxelManip::l_set_param2_at_helper(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, lua_upvalueindex(1));
 	MMVManip *vm = o->vm;
-	lua_Integer i = lua_tointeger(L, 2)-1;
+	u32 i = lua_tointeger(L, 2)-1;
 	u8 param2 = lua_tointeger(L, 3);
 
 	vm->m_data[i].param2 = param2;

--- a/src/script/lua_api/l_vmanip.h
+++ b/src/script/lua_api/l_vmanip.h
@@ -44,6 +44,11 @@ private:
 	static int l_read_from_map(lua_State *L);
 	static int l_get_data(lua_State *L);
 	static int l_set_data(lua_State *L);
+	static int l_get_content_at(lua_State *L);
+	static int l_set_content_at(lua_State *L);
+	static int l_get_content_at_helper(lua_State *L);
+	static int l_set_content_at_helper(lua_State *L);
+	static int l_get_data2(lua_State *L);
 	static int l_write_to_map(lua_State *L);
 
 	static int l_get_node_at(lua_State *L);
@@ -59,6 +64,12 @@ private:
 
 	static int l_get_param2_data(lua_State *L);
 	static int l_set_param2_data(lua_State *L);
+
+	static int l_get_param2_at(lua_State *L);
+	static int l_set_param2_at(lua_State *L);
+	static int l_get_param2_at_helper(lua_State *L);
+	static int l_set_param2_at_helper(lua_State *L);
+	static int l_get_param2_data2(lua_State *L);
 
 	static int l_was_modified(lua_State *L);
 	static int l_get_emerged_area(lua_State *L);


### PR DESCRIPTION
Created this pr here so that people can view it easily since I ain't creating a pr to get this merge.

todo:
- [ ] rename commit
- [x] figure out why lighting get worse
    - It's due to the index being off by one
- [ ] ~~push upstream~~
- [ ] look into actually generating the noise on demand instead of bulk

using @paramat's riverdiv lua mapgen https://github.com/asl97/riverdev/commit/8cedbdde52ae6eda7e11b1d276b4842831dc0ef9

generate chunk minp (-1152 -32 -912) | before | after
| - | - | - |
[data usage]
riverdev data | 16384.5703125 | 0.7109375
riverdev content | 0 | 0
riverdev variable stuff | 0.453125 | 0.453125
riverdev noise | 0.5537109375 | 0.5537109375
riverdev 3d noise view | 81920.390625 | 1.484375
riverdev 2d noise view | 448.3515625 | 1.1171875
| <sup>riverdev noise view total</sup> | <sup>82368.7421875</sup> | <sup>2.6015625</sup>
riverdev mapgen | 221.40234375 | 11.1015625
riverdev total | 98975.721679688 | 15.4208984375
lua memory usage | 100501.63183594 | 1549.3720703125
[timing]
riverdev get data | 77.328 ms | 0.0060000000003946 ms
riverdev get noise | 3414.727 ms | 3209.132 ms
riverdev lua mapgen logic | 1239.318 ms | 4526.852 ms
riverdev set data | 54.06 ms | 0.0070000000000903 ms
riverdev lighting | 159.421 ms | 213.864 ms
riverdev write | 42.221999999999 ms | 40.872 ms
riverdev liquids | 98.02 ms | 118.501 ms
riverdev total | 5085.096 ms | 8109.234 ms